### PR TITLE
Add Send trait bounds to the Futures

### DIFF
--- a/src/client/async.rs
+++ b/src/client/async.rs
@@ -72,4 +72,4 @@ pub type Client<S> = Framed<S, MessageCodec<OwnedMessage>>;
 /// headers to see if the server accepted the protocol or other custom header.
 /// This crate will not automatically close the connection if the server refused
 /// to use the user protocols given to it, you must check that the server accepted.
-pub type ClientNew<S> = Box<Future<Item = (Client<S>, Headers), Error = WebSocketError>>;
+pub type ClientNew<S> = Box<Future<Item = (Client<S>, Headers), Error = WebSocketError> + Send>;

--- a/src/result.rs
+++ b/src/result.rs
@@ -26,7 +26,7 @@ pub mod async {
 
 	/// The most common Future in this library, it is simply some result `I` or
 	/// a `WebSocketError`. This is analogous to the `WebSocketResult` type.
-	pub type WebSocketFuture<I> = Box<Future<Item = I, Error = WebSocketError>>;
+	pub type WebSocketFuture<I> = Box<Future<Item = I, Error = WebSocketError> + Send>;
 }
 
 /// Represents a WebSocket error

--- a/src/server/async.rs
+++ b/src/server/async.rs
@@ -25,7 +25,7 @@ pub type Server<S> = WsServer<S, TcpListener>;
 /// struct which lets the user decide whether to turn the connection into a websocket
 /// connection or reject it.
 pub type Incoming<S> =
-	Box<Stream<Item = (Upgrade<S>, SocketAddr), Error = InvalidConnection<S, BytesMut>>>;
+	Box<Stream<Item = (Upgrade<S>, SocketAddr), Error = InvalidConnection<S, BytesMut>> + Send>;
 
 /// Asynchronous methods for creating an async server and accepting incoming connections.
 impl WsServer<NoTlsAcceptor, TcpListener> {

--- a/src/server/upgrade/async.rs
+++ b/src/server/upgrade/async.rs
@@ -128,7 +128,10 @@ where
 		self.internal_reject(Some(headers))
 	}
 
-	fn internal_reject(mut self, headers: Option<&Headers>) -> SinkSend<Framed<S, HttpServerCodec>> {
+	fn internal_reject(
+		mut self,
+		headers: Option<&Headers>,
+	) -> SinkSend<Framed<S, HttpServerCodec>> {
 		if let Some(custom) = headers {
 			self.headers.extend(custom.iter());
 		}


### PR DESCRIPTION
Tokio's executor trait requires `Send` to be implemented on the future to be spawned.