### PR TITLE
Update native-tls and tokio-tls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,9 +27,9 @@ base64 = "0.6"
 futures = { version = "0.1", optional = true }
 tokio-core = { version = "0.1", optional = true }
 tokio-io = { version = "^0.1.2", optional = true }
-tokio-tls = { version = "0.1", optional = true }
+tokio-tls = { version = "0.2.0", optional = true }
 bytes = { version = "0.4", optional = true }
-native-tls = { version = "^0.1.2", optional = true }
+native-tls = { version = "0.2.1", optional = true }
 
 [dev-dependencies]
 futures-cpupool = "0.1"

--- a/src/result.rs
+++ b/src/result.rs
@@ -140,7 +140,7 @@ impl<T> From<TlsHandshakeError<T>> for WebSocketError {
 	fn from(err: TlsHandshakeError<T>) -> WebSocketError {
 		match err {
 			TlsHandshakeError::Failure(_) => WebSocketError::TlsHandshakeFailure,
-			TlsHandshakeError::Interrupted(_) => WebSocketError::TlsHandshakeInterruption,
+			TlsHandshakeError::WouldBlock(_) => WebSocketError::TlsHandshakeInterruption,
 		}
 	}
 }

--- a/src/server/async.rs
+++ b/src/server/async.rs
@@ -13,7 +13,7 @@ pub use tokio_core::reactor::Handle;
 #[cfg(any(feature = "async-ssl"))]
 use native_tls::TlsAcceptor;
 #[cfg(any(feature = "async-ssl"))]
-use tokio_tls::{TlsAcceptorExt, TlsStream};
+use tokio_tls::{TlsAcceptor as TlsAcceptorExt, TlsStream};
 
 /// The asynchronous specialization of a websocket server.
 /// Use this struct to create asynchronous servers.
@@ -105,7 +105,7 @@ impl WsServer<TlsAcceptor, TcpListener> {
 	/// (https://github.com/cyderize/rust-websocket/blob/master/examples/async-server.rs)
 	/// example for a good echo server example.
 	pub fn incoming(self) -> Incoming<TlsStream<TcpStream>> {
-		let acceptor = self.ssl_acceptor;
+		let acceptor = TlsAcceptorExt::from(self.ssl_acceptor);
 		let future = self
 			.listener
 			.incoming()
@@ -116,7 +116,7 @@ impl WsServer<TlsAcceptor, TcpListener> {
 				error: e.into(),
 			}).and_then(move |(stream, a)| {
 				acceptor
-					.accept_async(stream)
+					.accept(stream)
 					.map_err(|e| {
 						InvalidConnection {
 							stream: None,

--- a/src/server/sync.rs
+++ b/src/server/sync.rs
@@ -109,7 +109,7 @@ impl WsServer<TlsAcceptor, TcpListener> {
 	/// use std::fs::File;
 	/// use websocket::Message;
 	/// use websocket::sync::Server;
-	/// use native_tls::{Pkcs12, TlsAcceptor};
+	/// use native_tls::{Identity, TlsAcceptor};
 	///
 	/// // In this example we retrieve our keypair and certificate chain from a PKCS #12 archive,
 	/// // but but they can also be retrieved from, for example, individual PEM- or DER-formatted
@@ -117,9 +117,9 @@ impl WsServer<TlsAcceptor, TcpListener> {
 	/// let mut file = File::open("identity.pfx").unwrap();
 	/// let mut pkcs12 = vec![];
 	/// file.read_to_end(&mut pkcs12).unwrap();
-	/// let pkcs12 = Pkcs12::from_der(&pkcs12, "hacktheplanet").unwrap();
+	/// let pkcs12 = Identity::from_pkcs12(&pkcs12, "hacktheplanet").unwrap();
 	///
-	/// let acceptor = TlsAcceptor::builder(pkcs12).unwrap().build().unwrap();
+	/// let acceptor = TlsAcceptor::builder(pkcs12).build().unwrap();
 	///
 	/// let server = Server::bind_secure("127.0.0.1:1234", acceptor).unwrap();
 	///


### PR DESCRIPTION
Native-tls 0.1 uses outdated `openssl` crate that doesn't build with OpenSSL 1.1.1 (Arch Linux is already using it and openSUSE Tumbleweed will update in a few days).
Updating native-tls also fixes few issues with static OpenSSL builds.

It throws warnings like:
```
warning: use of deprecated item 'tokio_io::AsyncRead::framed': Use tokio_codec::Decoder::framed instead
   --> src/server/upgrade/async.rs:221:5
    |
221 |             .framed(HttpServerCodec)
    |  
```
But I couldn't manage to fix them.