### PR TITLE
Added From<String> & From<Vec<u8>> for OwnedMessage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ before_script:
 
 install:
   - rustup component add rustfmt
-  - rustup component add clippy
+  - rustup component add clippy --toolchain=nightly || cargo install --git https://github.com/rust-lang/rust-clippy/ --force clippy
 
 script:
   - cargo fmt -- --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ before_script:
   - export PATH="$PATH:$HOME/.cargo/bin"
 
 install:
-  - rustup component add rustfmt-preview
-  - rustup component add clippy-preview
+  - rustup component add rustfmt
+  - rustup component add clippy
 
 script:
   - cargo fmt -- --version

--- a/src/message.rs
+++ b/src/message.rs
@@ -436,6 +436,18 @@ impl ws::dataframe::DataFrame for OwnedMessage {
 	}
 }
 
+impl From<String> for OwnedMessage {
+    fn from(text: String) -> Self {
+        OwnedMessage::Text(text)
+    }
+}
+
+impl From<Vec<u8>> for OwnedMessage {
+    fn from(buf: Vec<u8>) -> Self {
+        OwnedMessage::Binary(buf)
+    }
+}
+
 impl<'m> From<Message<'m>> for OwnedMessage {
 	fn from(message: Message<'m>) -> Self {
 		match message.opcode {

--- a/src/message.rs
+++ b/src/message.rs
@@ -437,15 +437,15 @@ impl ws::dataframe::DataFrame for OwnedMessage {
 }
 
 impl From<String> for OwnedMessage {
-    fn from(text: String) -> Self {
-        OwnedMessage::Text(text)
-    }
+	fn from(text: String) -> Self {
+		OwnedMessage::Text(text)
+	}
 }
 
 impl From<Vec<u8>> for OwnedMessage {
-    fn from(buf: Vec<u8>) -> Self {
-        OwnedMessage::Binary(buf)
-    }
+	fn from(buf: Vec<u8>) -> Self {
+		OwnedMessage::Binary(buf)
+	}
 }
 
 impl<'m> From<Message<'m>> for OwnedMessage {


### PR DESCRIPTION
This adds `From<String>` & `From<Vec<u8>>` for OwnedMessage. Note that this means that it is impossible for a `Vec<u8>` message to be implicitly converted into a `OwnedMessage::Ping` or a `OwnedMessage::Pong`. This would fix #203.