### PR TITLE
Implement `AsTcpStream` for `Box<dyn AsTcpStream>`

### DIFF
--- a/src/stream.rs
+++ b/src/stream.rs
@@ -177,7 +177,7 @@ pub mod sync {
 
 	impl<T> AsTcpStream for Box<T>
 	where
-		T: AsTcpStream,
+		T: AsTcpStream + ?Sized,
 	{
 		fn as_tcp(&self) -> &TcpStream {
 			self.deref().as_tcp()


### PR DESCRIPTION
The current `impl<T: AsTcpStream> AsTcpStream for Box<T>` requires `T: Sized`. This means that anyone using `ClientBuilder::connect` will not be able to call the various `shutdown` methods, since the returned type is `Box<dyn NetworkStream + Send>`. After this change, the modified impl will apply to `Box<dyn NetworkStream + Send>`, which was presumably always intended.