### PR TITLE
Also assume websockets over HTTPS are secure

### DIFF
--- a/src/client/builder.rs
+++ b/src/client/builder.rs
@@ -888,6 +888,7 @@ impl<'u> ClientBuilder<'u> {
 	}
 
 	/// Check whether the given URL uses a secure scheme, e.g. `wss` or `https`.
+	#[cfg(feature = "sync-ssl")]
 	fn is_secure_url(&self) -> bool {
 		let scheme = self.url.scheme();
 		scheme == "wss" || scheme == "https"

--- a/src/client/builder.rs
+++ b/src/client/builder.rs
@@ -396,7 +396,7 @@ impl<'u> ClientBuilder<'u> {
 	) -> WebSocketResult<Client<Box<NetworkStream + Send>>> {
 		let tcp_stream = self.establish_tcp(None)?;
 
-		let boxed_stream: Box<NetworkStream + Send> = if self.url.scheme() == "wss" {
+		let boxed_stream: Box<NetworkStream + Send> = if self.is_secure_url() {
 			Box::new(self.wrap_ssl(tcp_stream, ssl_config)?)
 		} else {
 			Box::new(tcp_stream)
@@ -885,6 +885,12 @@ impl<'u> ClientBuilder<'u> {
 		}
 
 		Ok(())
+	}
+
+	/// Check whether the given URL uses a secure scheme, e.g. `wss` or `https`.
+	fn is_secure_url(&self) -> bool {
+		let scheme = self.url.scheme();
+		scheme == "wss" || scheme == "https"
 	}
 
 	#[cfg(any(feature = "sync", feature = "async"))]


### PR DESCRIPTION
This PR changes `connect()` on `ClientBuilder` to also assume the `https` scheme is secure, instead of just `wss`.

This change is _required_ for an application I'm developing, in which a `https` URL is upgraded to a secure web socket (for Firefox Send v3 to be exact, using `https://host/api/upload` for web sockets).

It would be awesome if this change could be accepted and published to crates.io, as the crate I'm working on is dependent on this to work.