### PR TITLE
Remove a lot of unnecessary tokio deps (udp, fs, uds and so on)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,18 +25,26 @@ byteorder = "1.0"
 sha1 = "0.6"
 base64 = "0.10.0"
 futures = { version = "0.1", optional = true }
-tokio = { version = "0.1", optional = true }
+tokio-io = { version = "0.1", optional = true }
 tokio-tls = { version = "0.2.0", optional = true }
+tokio-tcp = { version = "0.1", optional = true }
+tokio-codec = { version = "0.1", optional = true }
+tokio-reactor = { version = "0.1", optional = true }
 bytes = { version = "0.4", optional = true }
 native-tls = { version = "0.2.1", optional = true }
 
 [dev-dependencies]
 futures-cpupool = "0.1"
 
+[dev-dependencies.tokio]
+version = "0.1"
+default-features = false
+features = ["codec", "tcp", "rt-full"]
+
 [features]
 default = ["sync", "sync-ssl", "async", "async-ssl"]
 sync = []
 sync-ssl = ["native-tls", "sync"]
-async = ["tokio", "bytes", "futures"]
+async = ["bytes", "futures", "tokio-io", "tokio-tcp", "tokio-reactor", "tokio-codec"]
 async-ssl = ["native-tls", "tokio-tls", "async"]
 nightly = ["hyper/nightly"]

--- a/src/client/async.rs
+++ b/src/client/async.rs
@@ -46,9 +46,9 @@
 
 pub use futures::Future;
 use hyper::header::Headers;
-pub use tokio::codec::Framed;
-pub use tokio::net::TcpStream;
-pub use tokio::reactor::Handle;
+pub use tokio_codec::Framed;
+pub use tokio_reactor::Handle;
+pub use tokio_tcp::TcpStream;
 
 use codec::ws::MessageCodec;
 use message::OwnedMessage;

--- a/src/client/builder.rs
+++ b/src/client/builder.rs
@@ -47,10 +47,10 @@ mod async_imports {
 	pub use futures::future;
 	pub use futures::Stream as FutureStream;
 	pub use futures::{Future, IntoFuture, Sink};
-	pub use tokio::codec::FramedParts;
-	pub use tokio::codec::{Decoder, Framed};
-	pub use tokio::net::TcpStream as TcpStreamNew;
-	pub use tokio::reactor::Handle;
+	pub use tokio_codec::FramedParts;
+	pub use tokio_codec::{Decoder, Framed};
+	pub use tokio_reactor::Handle;
+	pub use tokio_tcp::TcpStream as TcpStreamNew;
 	#[cfg(feature = "async-ssl")]
 	pub use tokio_tls::TlsConnector as TlsConnectorExt;
 	pub use ws::util::update_framed_codec;

--- a/src/codec/http.rs
+++ b/src/codec/http.rs
@@ -16,7 +16,7 @@ use hyper::uri::RequestUri;
 use std::error::Error;
 use std::fmt::{self, Display, Formatter};
 use std::io::{self, Write};
-use tokio::codec::{Decoder, Encoder};
+use tokio_codec::{Decoder, Encoder};
 
 #[derive(Copy, Clone, Debug)]
 ///A codec to be used with `tokio` codecs that can serialize HTTP requests and

--- a/src/codec/ws.rs
+++ b/src/codec/ws.rs
@@ -7,8 +7,6 @@
 //! For websocket messages, see the documentation for `MessageCodec`, for
 //! dataframes see the documentation for `DataFrameCodec`
 
-extern crate tokio;
-
 use std::borrow::Borrow;
 use std::io::Cursor;
 use std::marker::PhantomData;
@@ -16,8 +14,8 @@ use std::mem;
 
 use bytes::BufMut;
 use bytes::BytesMut;
-use tokio::codec::Decoder;
-use tokio::codec::Encoder;
+use tokio_codec::Decoder;
+use tokio_codec::Encoder;
 
 use dataframe::DataFrame;
 use message::OwnedMessage;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,8 +47,16 @@ extern crate hyper;
 extern crate native_tls;
 extern crate rand;
 extern crate sha1;
-#[cfg(feature = "async")]
+#[cfg(test)]
 extern crate tokio;
+#[cfg(feature = "async")]
+extern crate tokio_codec;
+#[cfg(feature = "async")]
+extern crate tokio_io;
+#[cfg(feature = "async")]
+extern crate tokio_reactor;
+#[cfg(feature = "async")]
+extern crate tokio_tcp;
 #[cfg(feature = "async-ssl")]
 extern crate tokio_tls;
 extern crate unicase;
@@ -150,9 +158,9 @@ pub mod async {
 	pub use result::async::WebSocketFuture;
 
 	pub use futures;
-	pub use tokio::net::TcpListener;
-	pub use tokio::net::TcpStream;
-	pub use tokio::reactor::Handle;
+	pub use tokio_reactor::Handle;
+	pub use tokio_tcp::TcpListener;
+	pub use tokio_tcp::TcpStream;
 }
 
 pub use self::client::builder::ClientBuilder;

--- a/src/server/async.rs
+++ b/src/server/async.rs
@@ -7,8 +7,8 @@ use server::{NoTlsAcceptor, WsServer};
 use std::io;
 use std::net::SocketAddr;
 use std::net::ToSocketAddrs;
-use tokio::net::{TcpListener, TcpStream};
-pub use tokio::reactor::Handle;
+pub use tokio_reactor::Handle;
+use tokio_tcp::{TcpListener, TcpStream};
 
 #[cfg(any(feature = "async-ssl"))]
 use native_tls::TlsAcceptor;

--- a/src/server/sync.rs
+++ b/src/server/sync.rs
@@ -11,9 +11,9 @@ use std::net::{SocketAddr, TcpListener, TcpStream, ToSocketAddrs};
 #[cfg(feature = "async")]
 use server::async;
 #[cfg(feature = "async")]
-use tokio::net::TcpListener as AsyncTcpListener;
+use tokio_reactor::Handle;
 #[cfg(feature = "async")]
-use tokio::reactor::Handle;
+use tokio_tcp::TcpListener as AsyncTcpListener;
 
 /// Either the stream was established and it sent a websocket handshake
 /// which represents the `Ok` variant, or there was an error (this is the

--- a/src/server/upgrade/async.rs
+++ b/src/server/upgrade/async.rs
@@ -18,7 +18,7 @@ use hyper::http::h1::Incoming;
 use hyper::status::StatusCode;
 use std::io::{self, ErrorKind};
 use stream::async::Stream;
-use tokio::codec::{Decoder, Framed, FramedParts};
+use tokio_codec::{Decoder, Framed, FramedParts};
 use ws::util::update_framed_codec;
 
 /// An asynchronous websocket upgrade.

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -70,9 +70,9 @@ pub mod async {
 	pub use super::ReadWritePair;
 	use futures::Poll;
 	use std::io::{self, Read, Write};
-	pub use tokio::io::{AsyncRead, AsyncWrite};
-	pub use tokio::io::{ReadHalf, WriteHalf};
-	pub use tokio::net::TcpStream;
+	pub use tokio_io::io::{ReadHalf, WriteHalf};
+	pub use tokio_io::{AsyncRead, AsyncWrite};
+	pub use tokio_tcp::TcpStream;
 
 	/// A stream that can be read from and written to asynchronously.
 	/// This let's us abstract over many async streams like tcp, ssl,

--- a/src/ws/util/mod.rs
+++ b/src/ws/util/mod.rs
@@ -7,7 +7,7 @@ use std::str::from_utf8;
 use std::str::Utf8Error;
 
 #[cfg(feature = "async")]
-use tokio::codec::{Framed, FramedParts};
+use tokio_codec::{Framed, FramedParts};
 
 /// Transforms a u8 slice into an owned String
 pub fn bytes_to_string(data: &[u8]) -> Result<String, Utf8Error> {


### PR DESCRIPTION

Before:

* On `cargo build` there are 112 deps
* On `cargo test` there are 126 deps

After:

* On `cargo build` there are 95 deps
* On `cargo test` there are 122 deps