### PR TITLE
Add a simple impl Debug for InvalidConnection

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -3,6 +3,7 @@
 use native_tls::TlsAcceptor;
 
 use self::upgrade::{HyperIntoWsError, Request};
+use std::fmt::{Debug, Formatter, Result as FmtResult};
 use stream::Stream;
 
 pub mod upgrade;
@@ -46,6 +47,20 @@ where
 	pub buffer: Option<B>,
 	/// the cause of the failed websocket connection setup
 	pub error: HyperIntoWsError,
+}
+
+impl<S, B> Debug for InvalidConnection<S, B>
+where
+	S: Stream,
+{
+	fn fmt(&self, fmt: &mut Formatter<'_>) -> FmtResult {
+		fmt.debug_struct("InvalidConnection")
+			.field("stream", &String::from("..."))
+			.field("parsed", &String::from("..."))
+			.field("buffer", &String::from("..."))
+			.field("error", &self.error)
+			.finish()
+	}
 }
 
 /// Represents a WebSocket server which can work with either normal


### PR DESCRIPTION
Closes #153

This is how an error looks like:

```
Finished dev [unoptimized + debuginfo] target(s) in 2.33s
 Running `target/debug/examples/async-server`
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: InvalidConnection { stream: "...", parsed: "...", buffer: "...", error: Io(Custom { kind: ConnectionReset, error: StringError("Connection dropped before handshake could be read") }) }', src/libcore/result.rs:997:5
note: Run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
```

Even if you don't map errors:

```
let f = server
  .incoming()
  .for_each(move |(upgrade, addr)| {
```