### PR TITLE
Provide an implementation of local_addr for Async servers

### DIFF
--- a/src/server/async.rs
+++ b/src/server/async.rs
@@ -4,7 +4,7 @@ use futures;
 use futures::{Future, Stream};
 use server::upgrade::async::{IntoWs, Upgrade};
 use server::InvalidConnection;
-use server::{NoTlsAcceptor, WsServer};
+use server::{NoTlsAcceptor, OptionalTlsAcceptor, WsServer};
 use std;
 use std::io;
 use std::net::SocketAddr;
@@ -28,6 +28,16 @@ pub type Server<S> = WsServer<S, TcpListener>;
 /// connection or reject it.
 pub type Incoming<S> =
 	Box<Stream<Item = (Upgrade<S>, SocketAddr), Error = InvalidConnection<S, BytesMut>> + Send>;
+
+impl<S> WsServer<S, TcpListener>
+where
+	S: OptionalTlsAcceptor,
+{
+	/// Get the socket address of this server
+	pub fn local_addr(&self) -> io::Result<SocketAddr> {
+		self.listener.local_addr()
+	}
+}
 
 /// Asynchronous methods for creating an async server and accepting incoming connections.
 impl WsServer<NoTlsAcceptor, TcpListener> {


### PR DESCRIPTION
When you bind to a dynamically allocated port by specifying 0, it is necessary to query the socket after `bind()` to see which port was selected by the OS. A `local_addr()` wrapper is provided for sync. This change adds it for async.