### PR TITLE
Handle username/password from URL

### DIFF
--- a/src/client/builder.rs
+++ b/src/client/builder.rs
@@ -2,7 +2,7 @@
 
 use header::extensions::Extension;
 use header::{Origin, WebSocketExtensions, WebSocketKey, WebSocketProtocol, WebSocketVersion};
-use hyper::header::{Header, HeaderFormat, Headers};
+use hyper::header::{Authorization, Basic, Header, HeaderFormat, Headers};
 use hyper::version::HttpVersion;
 use std::borrow::Cow;
 use std::convert::Into;
@@ -817,6 +817,17 @@ impl<'u> ClientBuilder<'u> {
 			});
 		}
 
+		// handle username/password from URL
+		if !self.url.username().is_empty() {
+			self.headers.set(Authorization(Basic {
+				username: self.url.username().to_owned(),
+				password: match self.url.password() {
+					Some(password) => Some(password.to_owned()),
+					None => None,
+				},
+			}));
+		}
+
 		self.headers
 			.set(Connection(vec![ConnectionOption::ConnectionHeader(
 				UniCase("Upgrade".to_string()),
@@ -979,5 +990,15 @@ mod tests {
 		assert!(protos.contains(&"boogaloo".to_string()));
 		assert!(protos.contains(&"electric".to_string()));
 		assert!(!protos.contains(&"rust-websocket".to_string()));
+	}
+
+	#[test]
+	fn build_client_with_username_password() {
+		use super::*;
+		let mut builder = ClientBuilder::new("ws://john:pswd@127.0.0.1:8080/hello").unwrap();
+		let _request = builder.build_request();
+		let auth = builder.headers.get::<Authorization<Basic>>().unwrap();
+		assert!(auth.username == "john");
+		assert_eq!(auth.password, Some("pswd".to_owned()));
 	}
 }


### PR DESCRIPTION
This makes `ws://john:pswd@example.org/` to be correctly handled instead of being silently ignored.

Rationale: this project is supposedly implementing RFC6455 that states[1]:

    URI scheme syntax
       Using the ABNF [RFC5234] syntax and ABNF terminals from the URI
       specification [RFC3986]:

            "ws:" "//" authority path-abempty [ "?" query ]

And RFC3986 states[2] that 'authority' may include a username and password.

[1] https://tools.ietf.org/html/rfc6455#section-11.1.1
[2] https://tools.ietf.org/html/rfc3986#section-3.2.1