### PR TITLE
Async client example: Don't close twice

### DIFF
--- a/examples/async-client.rs
+++ b/examples/async-client.rs
@@ -56,7 +56,6 @@ fn main() {
 				.filter_map(|message| {
 					println!("Received Message: {:?}", message);
 					match message {
-						OwnedMessage::Close(e) => Some(OwnedMessage::Close(e)),
 						OwnedMessage::Ping(d) => Some(OwnedMessage::Pong(d)),
 						_ => None,
 					}


### PR DESCRIPTION
As far as i can tell, the server doesn't initiate the close handshake, so the client should just consider the handshake finished when it receives the acknowledgment and probably just wait for the server to close the underlying connection.

This stops if from trying to start a second close handshake.

It's not exactly clear to me how this avoids dropping the underlying connection before the server closes it now???

There is also a warning:
```
warning: unused `futures::stream::Select` in tuple element 0 that must be used

  --> examples/async-client.rs:67:2
   |
67 |     runtime.block_on(runner).unwrap();
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(unused_must_use)]` on by default
   = note: streams do nothing unless polled

```

Given how convoluted types get here, I haven't exactly bothered getting to the bottom of this warning.

I think some extra comments would be nice in example code.