### PR TITLE
Expose native_tls as it's needed to use your API

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@ extern crate bytes;
 pub extern crate futures;
 extern crate hyper;
 #[cfg(any(feature = "sync-ssl", feature = "async-ssl"))]
-extern crate native_tls;
+pub extern crate native_tls;
 #[cfg(test)]
 extern crate tokio;
 #[cfg(feature = "async")]


### PR DESCRIPTION
In order to use any of the connect functions I would be required to depend on native_tls directly. It would be easier if you exposed the version you depend on.
```
use native_tls::TlsConnector; //Errors out currently
use websocket::native_tls::{TlsConnector, Certificate}; //What I propose

let mut file = File::open("cert.pem")?;
let mut data:Vec<u8> = Vec::new();
file.read_to_end(&mut data);
let root_ca = Certificate::from_pem(&data)?;
let connector = TlsConnector::builder().add_root_certificate(root_ca).build()?;

let mut builder: ClientBuilder = ClientBuilder::from_url(&self.url);
let mut client = builder.connect(Some(connector))?;
```