### PR TITLE
Improve Display impl for WebSocketOtherError

### DIFF
--- a/src/result.rs
+++ b/src/result.rs
@@ -66,7 +66,7 @@ impl fmt::Display for WebSocketOtherError {
 	fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
 		match self {
 			WebSocketOtherError::RequestError(e) => write!(fmt, "WebSocket request error: {}", e)?,
-			WebSocketOtherError::ResponseError(e) => write!(fmt, "WebSocket request error: {}", e)?,
+			WebSocketOtherError::ResponseError(e) => write!(fmt, "WebSocket response error: {}", e)?,
 			WebSocketOtherError::StatusCodeError(e) => write!(
 				fmt,
 				"WebSocketError: Received unexpected status code ({})",

--- a/src/result.rs
+++ b/src/result.rs
@@ -66,7 +66,9 @@ impl fmt::Display for WebSocketOtherError {
 	fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
 		match self {
 			WebSocketOtherError::RequestError(e) => write!(fmt, "WebSocket request error: {}", e)?,
-			WebSocketOtherError::ResponseError(e) => write!(fmt, "WebSocket response error: {}", e)?,
+			WebSocketOtherError::ResponseError(e) => {
+				write!(fmt, "WebSocket response error: {}", e)?
+			}
 			WebSocketOtherError::StatusCodeError(e) => write!(
 				fmt,
 				"WebSocketError: Received unexpected status code ({})",

--- a/src/result.rs
+++ b/src/result.rs
@@ -64,8 +64,22 @@ pub enum WebSocketOtherError {
 
 impl fmt::Display for WebSocketOtherError {
 	fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-		fmt.write_str("WebSocketError: ")?;
-		fmt.write_str(self.description())?;
+		match self {
+			WebSocketOtherError::RequestError(e) => write!(fmt, "WebSocket request error: {}", e)?,
+			WebSocketOtherError::ResponseError(e) => write!(fmt, "WebSocket request error: {}", e)?,
+			WebSocketOtherError::StatusCodeError(e) => write!(
+				fmt,
+				"WebSocketError: Received unexpected status code ({})",
+				e
+			)?,
+			WebSocketOtherError::HttpError(e) => write!(fmt, "WebSocket HTTP error: {}", e)?,
+			WebSocketOtherError::UrlError(e) => write!(fmt, "WebSocket URL parse error: {}", e)?,
+			WebSocketOtherError::IoError(e) => write!(fmt, "WebSocket I/O error: {}", e)?,
+			WebSocketOtherError::WebSocketUrlError(e) => e.fmt(fmt)?,
+			#[cfg(any(feature = "sync-ssl", feature = "async-ssl"))]
+			WebSocketOtherError::TlsError(e) => write!(fmt, "WebSocket SSL error: {}", e)?,
+			_ => write!(fmt, "WebSocketError: {}", self.description())?,
+		}
 		Ok(())
 	}
 }


### PR DESCRIPTION
This PR provides a more informative error message when a `WebSocketOtherError` is displayed. The main driver of this change is vi/websocat#55, which would then indicate the concrete status code obtained from the server.