### PR TITLE
Replace sha1 crate with sha-1

### DIFF
--- a/websocket-base/Cargo.toml
+++ b/websocket-base/Cargo.toml
@@ -20,7 +20,7 @@ byteorder = "1.0"
 rand = "0.6.1"
 bitflags = "1.0.4"
 base64 = "0.10.0"
-sha1 = "0.6"
+sha-1 = "0.8"
 bytes = { version = "0.4", optional = true }
 futures = { version = "0.1", optional = true }
 native-tls = { version = "0.2.1", optional = true }

--- a/websocket-base/src/header.rs
+++ b/websocket-base/src/header.rs
@@ -12,7 +12,7 @@ pub mod names {
 
 extern crate base64;
 extern crate sha1;
-use self::sha1::Sha1;
+use sha1::{Digest, Sha1};
 
 use crate::result::{WebSocketError, WebSocketResult};
 use std::fmt::{self, Debug};
@@ -105,10 +105,8 @@ impl WebSocketAccept {
 		let mut concat_key = String::with_capacity(serialized.len() + 36);
 		concat_key.push_str(&serialized[..]);
 		concat_key.push_str(MAGIC_GUID);
-		let mut sha1 = Sha1::new();
-		sha1.update(concat_key.as_bytes());
-		let bytes = sha1.digest().bytes();
-		WebSocketAccept(bytes)
+		let hash = Sha1::digest(concat_key.as_bytes());
+		WebSocketAccept(hash.into())
 	}
 	/// Return the Base64 encoding of this WebSocketAccept
 	pub fn serialize(&self) -> String {


### PR DESCRIPTION
This other crate is being maintained, it offers better performances (when using the `asm` feature, especially [on AArch64](https://github.com/RustCrypto/hashes/pull/97)).  It also allows deduplicating SHA-1 crates in cargo-web.