### PR TITLE
Remove deprecated usage of the "description" and "cause" functions

### DIFF
--- a/src/codec/http.rs
+++ b/src/codec/http.rs
@@ -220,18 +220,14 @@ pub enum HttpCodecError {
 
 impl Display for HttpCodecError {
 	fn fmt(&self, fmt: &mut Formatter) -> Result<(), fmt::Error> {
-		fmt.write_str(self.description())
+		match self {
+			HttpCodecError::Io(e) => fmt.write_str(e.to_string().as_str()),
+			HttpCodecError::Http(e) => fmt.write_str(e.to_string().as_str()),
+		}
 	}
 }
 
 impl Error for HttpCodecError {
-	fn description(&self) -> &str {
-		match *self {
-			HttpCodecError::Io(ref e) => e.description(),
-			HttpCodecError::Http(ref e) => e.description(),
-		}
-	}
-
 	fn cause(&self) -> Option<&dyn Error> {
 		match *self {
 			HttpCodecError::Io(ref error) => Some(error),

--- a/src/codec/http.rs
+++ b/src/codec/http.rs
@@ -228,7 +228,7 @@ impl Display for HttpCodecError {
 }
 
 impl Error for HttpCodecError {
-	fn cause(&self) -> Option<&dyn Error> {
+	fn source(&self) -> Option<&(dyn Error + 'static)> {
 		match *self {
 			HttpCodecError::Io(ref error) => Some(error),
 			HttpCodecError::Http(ref error) => Some(error),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,11 +65,11 @@ macro_rules! upsert_header {
 		if $headers.has::<$header>() {
 			if let Some($pat) = $headers.get_mut::<$header>() {
 				$some_match
-				}
+			}
 		} else {
 			$headers.set($default);
-			}
-		}};
+		}
+	}};
 }
 
 pub use websocket_base::dataframe;

--- a/src/result.rs
+++ b/src/result.rs
@@ -65,47 +65,33 @@ pub enum WebSocketOtherError {
 impl fmt::Display for WebSocketOtherError {
 	fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
 		match self {
-			WebSocketOtherError::RequestError(e) => write!(fmt, "WebSocket request error: {}", e)?,
+			WebSocketOtherError::RequestError(e) => write!(fmt, "WebSocket request error: {}", e),
 			WebSocketOtherError::ResponseError(e) => {
-				write!(fmt, "WebSocket response error: {}", e)?
+				write!(fmt, "WebSocket response error: {}", e)
 			}
 			WebSocketOtherError::StatusCodeError(e) => write!(
 				fmt,
 				"WebSocketError: Received unexpected status code ({})",
 				e
-			)?,
-			WebSocketOtherError::HttpError(e) => write!(fmt, "WebSocket HTTP error: {}", e)?,
-			WebSocketOtherError::UrlError(e) => write!(fmt, "WebSocket URL parse error: {}", e)?,
-			WebSocketOtherError::IoError(e) => write!(fmt, "WebSocket I/O error: {}", e)?,
-			WebSocketOtherError::WebSocketUrlError(e) => e.fmt(fmt)?,
+			),
+			WebSocketOtherError::HttpError(e) => write!(fmt, "WebSocket HTTP error: {}", e),
+			WebSocketOtherError::UrlError(e) => write!(fmt, "WebSocket URL parse error: {}", e),
+			WebSocketOtherError::IoError(e) => write!(fmt, "WebSocket I/O error: {}", e),
+			WebSocketOtherError::WebSocketUrlError(e) => e.fmt(fmt),
 			#[cfg(any(feature = "sync-ssl", feature = "async-ssl"))]
-			WebSocketOtherError::TlsError(e) => write!(fmt, "WebSocket SSL error: {}", e)?,
-			_ => write!(fmt, "WebSocketError: {}", self.description())?,
+			WebSocketOtherError::TlsError(e) => write!(fmt, "WebSocket SSL error: {}", e),
+			WebSocketOtherError::ProtocolError(e) => write!(fmt, "WebSocketError: {}", e),
+			WebSocketOtherError::TlsHandshakeFailure => {
+				write!(fmt, "WebSocketError: {}", "TLS Handshake failure")
+			}
+			WebSocketOtherError::TlsHandshakeInterruption => {
+				write!(fmt, "WebSocketError: {}", "TLS Handshake interrupted")
+			}
 		}
-		Ok(())
 	}
 }
 
 impl Error for WebSocketOtherError {
-	fn description(&self) -> &str {
-		match *self {
-			WebSocketOtherError::RequestError(_) => "WebSocket request error",
-			WebSocketOtherError::ResponseError(_) => "WebSocket response error",
-			WebSocketOtherError::HttpError(_) => "HTTP failure",
-			WebSocketOtherError::UrlError(_) => "URL failure",
-			#[cfg(any(feature = "sync-ssl", feature = "async-ssl"))]
-			WebSocketOtherError::TlsError(_) => "TLS failure",
-			#[cfg(any(feature = "sync-ssl", feature = "async-ssl"))]
-			WebSocketOtherError::TlsHandshakeFailure => "TLS Handshake failure",
-			#[cfg(any(feature = "sync-ssl", feature = "async-ssl"))]
-			WebSocketOtherError::TlsHandshakeInterruption => "TLS Handshake interrupted",
-			WebSocketOtherError::WebSocketUrlError(_) => "WebSocket URL failure",
-			WebSocketOtherError::IoError(ref e) => e.description(),
-			WebSocketOtherError::ProtocolError(e) => e,
-			WebSocketOtherError::StatusCodeError(_) => "Received unexpected status code",
-		}
-	}
-
 	fn cause(&self) -> Option<&dyn Error> {
 		match *self {
 			WebSocketOtherError::HttpError(ref error) => Some(error),
@@ -197,20 +183,15 @@ pub enum WSUrlErrorKind {
 impl fmt::Display for WSUrlErrorKind {
 	fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
 		fmt.write_str("WebSocket Url Error: ")?;
-		fmt.write_str(self.description())?;
-		Ok(())
-	}
-}
-
-impl Error for WSUrlErrorKind {
-	fn description(&self) -> &str {
-		match *self {
-			WSUrlErrorKind::CannotSetFragment => "WebSocket URL cannot set fragment",
-			WSUrlErrorKind::InvalidScheme => "WebSocket URL invalid scheme",
-			WSUrlErrorKind::NoHostName => "WebSocket URL no host name provided",
+		match self {
+			WSUrlErrorKind::CannotSetFragment => fmt.write_str("WebSocket URL cannot set fragment"),
+			WSUrlErrorKind::InvalidScheme => fmt.write_str("WebSocket URL invalid scheme"),
+			WSUrlErrorKind::NoHostName => fmt.write_str("WebSocket URL no host name provided"),
 		}
 	}
 }
+
+impl Error for WSUrlErrorKind {}
 
 impl From<WebSocketOtherError> for WebSocketError {
 	fn from(e: WebSocketOtherError) -> WebSocketError {

--- a/src/result.rs
+++ b/src/result.rs
@@ -92,7 +92,7 @@ impl fmt::Display for WebSocketOtherError {
 }
 
 impl Error for WebSocketOtherError {
-	fn cause(&self) -> Option<&dyn Error> {
+	fn source(&self) -> Option<&(dyn Error + 'static)> {
 		match *self {
 			WebSocketOtherError::HttpError(ref error) => Some(error),
 			WebSocketOtherError::UrlError(ref error) => Some(error),

--- a/src/server/sync.rs
+++ b/src/server/sync.rs
@@ -292,7 +292,7 @@ mod tests {
 			Ok(_) => panic!("expected error"),
 			Err(e) => match e.error {
 				HyperIntoWsError::Io(ref e) if e.kind() == io::ErrorKind::WouldBlock => {}
-				_ => panic!("unexpected error {}"),
+				e => panic!("unexpected error {}", e),
 			},
 		}
 	}

--- a/src/server/upgrade/mod.rs
+++ b/src/server/upgrade/mod.rs
@@ -217,7 +217,7 @@ impl Display for HyperIntoWsError {
 }
 
 impl Error for HyperIntoWsError {
-	fn cause(&self) -> Option<&dyn Error> {
+	fn source(&self) -> Option<&(dyn Error + 'static)> {
 		match *self {
 			HyperIntoWsError::Io(ref e) => Some(e),
 			HyperIntoWsError::Parsing(ref e) => Some(e),

--- a/src/server/upgrade/mod.rs
+++ b/src/server/upgrade/mod.rs
@@ -191,27 +191,32 @@ pub enum HyperIntoWsError {
 
 impl Display for HyperIntoWsError {
 	fn fmt(&self, fmt: &mut Formatter) -> Result<(), fmt::Error> {
-		fmt.write_str(self.description())
+		match *self {
+			HyperIntoWsError::MethodNotGet => fmt.write_str("Request method must be GET"),
+			HyperIntoWsError::UnsupportedHttpVersion => {
+				fmt.write_str("Unsupported request HTTP version")
+			}
+			HyperIntoWsError::UnsupportedWebsocketVersion => {
+				fmt.write_str("Unsupported WebSocket version")
+			}
+			HyperIntoWsError::NoSecWsKeyHeader => fmt.write_str("Missing Sec-WebSocket-Key header"),
+			HyperIntoWsError::NoWsUpgradeHeader => {
+				fmt.write_str("Invalid Upgrade WebSocket header")
+			}
+			HyperIntoWsError::NoUpgradeHeader => fmt.write_str("Missing Upgrade WebSocket header"),
+			HyperIntoWsError::NoWsConnectionHeader => {
+				fmt.write_str("Invalid Connection WebSocket header")
+			}
+			HyperIntoWsError::NoConnectionHeader => {
+				fmt.write_str("Missing Connection WebSocket header")
+			}
+			HyperIntoWsError::Io(ref e) => fmt.write_str(e.to_string().as_str()),
+			HyperIntoWsError::Parsing(ref e) => fmt.write_str(e.to_string().as_str()),
+		}
 	}
 }
 
 impl Error for HyperIntoWsError {
-	fn description(&self) -> &str {
-		use self::HyperIntoWsError::*;
-		match *self {
-			MethodNotGet => "Request method must be GET",
-			UnsupportedHttpVersion => "Unsupported request HTTP version",
-			UnsupportedWebsocketVersion => "Unsupported WebSocket version",
-			NoSecWsKeyHeader => "Missing Sec-WebSocket-Key header",
-			NoWsUpgradeHeader => "Invalid Upgrade WebSocket header",
-			NoUpgradeHeader => "Missing Upgrade WebSocket header",
-			NoWsConnectionHeader => "Invalid Connection WebSocket header",
-			NoConnectionHeader => "Missing Connection WebSocket header",
-			Io(ref e) => e.description(),
-			Parsing(ref e) => e.description(),
-		}
-	}
-
 	fn cause(&self) -> Option<&dyn Error> {
 		match *self {
 			HyperIntoWsError::Io(ref e) => Some(e),

--- a/websocket-base/src/result.rs
+++ b/websocket-base/src/result.rs
@@ -54,12 +54,11 @@ impl fmt::Display for WebSocketError {
 }
 
 impl Error for WebSocketError {
-	#[allow(deprecated)]
-	fn cause(&self) -> Option<&dyn Error> {
+	fn source(&self) -> Option<&(dyn Error + 'static)> {
 		match *self {
 			WebSocketError::IoError(ref error) => Some(error),
 			WebSocketError::Utf8Error(ref error) => Some(error),
-			WebSocketError::Other(ref error) => error.cause(),
+			WebSocketError::Other(ref error) => error.source(),
 			_ => None,
 		}
 	}

--- a/websocket-base/src/result.rs
+++ b/websocket-base/src/result.rs
@@ -41,29 +41,19 @@ pub enum WebSocketError {
 
 impl fmt::Display for WebSocketError {
 	fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+		fmt.write_str("WebSocketError: ")?;
 		match self {
-			WebSocketError::Other(x) => x.fmt(fmt)?,
-			_ => {
-				fmt.write_str("WebSocketError: ")?;
-				fmt.write_str(self.description())?;
-			}
+			WebSocketError::ProtocolError(_) => fmt.write_str("WebSocket protocol error"),
+			WebSocketError::DataFrameError(_) => fmt.write_str("WebSocket data frame error"),
+			WebSocketError::NoDataAvailable => fmt.write_str("No data available"),
+			WebSocketError::IoError(_) => fmt.write_str("I/O failure"),
+			WebSocketError::Utf8Error(_) => fmt.write_str("UTF-8 failure"),
+			WebSocketError::Other(x) => x.fmt(fmt),
 		}
-		Ok(())
 	}
 }
 
 impl Error for WebSocketError {
-	fn description(&self) -> &str {
-		match *self {
-			WebSocketError::ProtocolError(_) => "WebSocket protocol error",
-			WebSocketError::DataFrameError(_) => "WebSocket data frame error",
-			WebSocketError::NoDataAvailable => "No data available",
-			WebSocketError::IoError(_) => "I/O failure",
-			WebSocketError::Utf8Error(_) => "UTF-8 failure",
-			WebSocketError::Other(ref e) => e.description(),
-		}
-	}
-
 	#[allow(deprecated)]
 	fn cause(&self) -> Option<&dyn Error> {
 		match *self {


### PR DESCRIPTION
Remove deprecated usage of the `description` function and replace it with `to_string` function.
Remove deprecated usage of the `cause` function and replace it with `source` function.

