### PR TITLE
Properly gate TLS error variants in Display impl

### DIFF
--- a/src/result.rs
+++ b/src/result.rs
@@ -81,9 +81,11 @@ impl fmt::Display for WebSocketOtherError {
 			#[cfg(any(feature = "sync-ssl", feature = "async-ssl"))]
 			WebSocketOtherError::TlsError(e) => write!(fmt, "WebSocket SSL error: {}", e),
 			WebSocketOtherError::ProtocolError(e) => write!(fmt, "WebSocketError: {}", e),
+			#[cfg(any(feature = "sync-ssl", feature = "async-ssl"))]
 			WebSocketOtherError::TlsHandshakeFailure => {
 				write!(fmt, "WebSocketError: {}", "TLS Handshake failure")
 			}
+			#[cfg(any(feature = "sync-ssl", feature = "async-ssl"))]
 			WebSocketOtherError::TlsHandshakeInterruption => {
 				write!(fmt, "WebSocketError: {}", "TLS Handshake interrupted")
 			}


### PR DESCRIPTION
Without the gating `websocket` fails to compile if neither of the TLS features is enabled.