### PR TITLE
chore(docs): remove mio async comments

### DIFF
--- a/examples/async-client.rs
+++ b/examples/async-client.rs
@@ -25,8 +25,6 @@ fn main() {
 	let (usr_msg, stdin_ch) = mpsc::channel(0);
 
 	// Spawn new thread to read user input
-	// stdin isn't supported in mio yet, so we use a thread
-	// see https://github.com/carllerche/mio/issues/321
 	thread::spawn(|| {
 		let mut input = String::new();
 		let mut stdin_sink = usr_msg.wait();

--- a/examples/ssl-client.rs
+++ b/examples/ssl-client.rs
@@ -19,8 +19,6 @@ fn main() {
 		.build()
 		.unwrap();
 
-	// standard in isn't supported in mio yet, so we use a thread
-	// see https://github.com/carllerche/mio/issues/321
 	let (usr_msg, stdin_ch) = mpsc::channel(0);
 	thread::spawn(|| {
 		let mut input = String::new();


### PR DESCRIPTION
The Mio comment in examples confused me a bit; I had to go into the issue to check whether it's done. Apparently, they implement it never: https://github.com/tokio-rs/mio/issues/321#issuecomment-342569610